### PR TITLE
add libatomic to target_link_libraries on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,7 @@ target_link_libraries(TracktionHelloWorld
     PUBLIC
         juce::juce_recommended_config_flags
         juce::juce_recommended_warning_flags)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(TracktionHelloWorld PRIVATE "-latomic")
+endif()


### PR DESCRIPTION
This fixes a linker error at the end of build process on Linux. Tested it on a AMD64 and ARM64. builds fine.